### PR TITLE
fixed mountpoints

### DIFF
--- a/lib/disks.js
+++ b/lib/disks.js
@@ -147,11 +147,11 @@ function detail(drive, callback) {
                     case'darwin':
                         getDetailNaN('df -kl | grep ' + drive + ' | awk \'{print $9}\'', function(e, d){
                             if (d) d = d.trim();
-                            callback(e, '\\');
+                            callback(e, d);
                         });
                         break;
                     case'win32':
-                      callback(null, '\\');
+                      callback(null, drive);
                       break;
                     case'linux':
                     default:


### PR DESCRIPTION
mac os x supported again: rollback one line from 0fa1424;
actually, mountpoint is path where volume is mounted. mountpoints for windows are A:, B:, C: and so on.
